### PR TITLE
Rename struct generic procedures

### DIFF
--- a/keyring-lib/backend/env.rkt
+++ b/keyring-lib/backend/env.rkt
@@ -52,10 +52,9 @@
 (struct env-keyring [base-key]
   #:methods
   gen:keyring
-  [(define get-password env-get-password)
-   (define set-password! env-set-password!)
-   (define delete-password! env-delete-password!)])
+  [(define get-password-proc env-get-password)
+   (define set-password-proc! env-set-password!)
+   (define delete-password-proc! env-delete-password!)])
 
 (define (make-keyring #:prefix base-env-key)
   (env-keyring base-env-key))
-

--- a/keyring-lib/private/interface.rkt
+++ b/keyring-lib/private/interface.rkt
@@ -99,14 +99,14 @@
 ;;
 ;; struct generics
 (define-generics keyring
-  [get-password     keyring service username]
-  [set-password!    keyring service username password]
-  [delete-password! keyring service username]
+  [get-password-proc     keyring service username]
+  [set-password-proc!    keyring service username password]
+  [delete-password-proc! keyring service username]
   #:derive-property
   prop:keyring
   (vector (λ (kr service username)
-            (get-password kr service username))
+            (get-password-proc kr service username))
           (λ (kr service username password)
-            (set-password! kr service username password))
+            (set-password-proc! kr service username password))
           (λ (kr service username)
-            (delete-password! kr service username))))
+            (delete-password-proc! kr service username))))

--- a/keyring-test/backend/test.rkt
+++ b/keyring-test/backend/test.rkt
@@ -24,17 +24,16 @@
 (struct test-keyring (service-name username secret-value)
   #:methods
   gen:keyring
-  [(define (get-password kr service-name username)
+  [(define (get-password-proc kr service-name username)
      (match kr
        [(test-keyring (== service-name) (== username) secret) secret]
        [_ #f]))
 
-   (define set-password! void)
-   (define delete-password! void)]
+   (define set-password-proc! void)
+   (define delete-password-proc! void)]
   #:transparent)
 
 (define (make-keyring #:service  service-name
                       #:username username
                       #:password password)
   (test-keyring service-name username (string->bytes/utf-8 password)))
-

--- a/keyring-test/tests/interface.rkt
+++ b/keyring-test/tests/interface.rkt
@@ -82,11 +82,11 @@
 
   (struct g:keyring (store)
     #:methods gen:keyring
-    [(define (get-password kr service username)
+    [(define (get-password-proc kr service username)
        (hash-ref (g:keyring-store kr) (cons service username) #f))
-     (define (set-password! kr service username password)
+     (define (set-password-proc! kr service username password)
        (hash-set! (g:keyring-store kr) (cons service username) password))
-     (define (delete-password! kr service username)
+     (define (delete-password-proc! kr service username)
        (hash-remove! (g:keyring-store kr) (cons service username)))])
 
   (define (make-g:keyring) (g:keyring (make-hash)))

--- a/keyring/scribblings/changelog.scrbl
+++ b/keyring/scribblings/changelog.scrbl
@@ -4,6 +4,16 @@
 
 @title{Changelog}
 
+@section{0.11.0}
+Release date: 2023/MM/DD
+@itemlist[
+  @item{Move tests into separate packages.}
+  @item{Reorganize the backends around @racket[prop:keyring]}
+  @item{Clean up error message formatting.}
+  @item{Add @var{null} backend as default when the @envvar{KEYRING}
+        environment variable is not set.}
+]
+
 @section{0.10.1}
 Release date: 2022/11/09
 @itemlist[

--- a/keyring/scribblings/keyring.scrbl
+++ b/keyring/scribblings/keyring.scrbl
@@ -108,7 +108,7 @@ stores which can be installed separately.
 @subsection{Struct Type Property Keyring Interface}
 @defthing[prop:keyring struct-type-property?]
 
-@subsection{Generic Keyring Interface}
+@subsection{Struct Generic Keyring Interface}
 @defidform[gen:keyring]
 
 @defproc[(get-password [keyring keyring?]

--- a/keyring/scribblings/keyring.scrbl
+++ b/keyring/scribblings/keyring.scrbl
@@ -105,7 +105,11 @@ stores which can be installed separately.
 
 @defmodule[keyring/interface]
 
-@subsection{Back End Keyring Methods}
+@subsection{Struct Type Property Keyring Interface}
+@defthing[prop:keyring struct-type-property?]
+
+@subsection{Generic Keyring Interface}
+@defidform[gen:keyring]
 
 @defproc[(get-password [keyring keyring?]
                        [service-name string?]
@@ -123,12 +127,7 @@ stores which can be installed separately.
                            [username string?])
          void?]
 
-@subsection{Generic Keyring Interface}
-
-@defidform[gen:keyring]
-
-@defthing[prop:keyring struct-type-property?]
-
+@subsection{Class Keyring Interface}
 @definterface[keyring<%> ()]{
   @defmethod[(get-password
                [service-name string?]


### PR DESCRIPTION
This renames the struct generic procedures to closer match interfaces like gen:custom-write.